### PR TITLE
Fix moving NTC code to libraries

### DIFF
--- a/Brewslave/configure
+++ b/Brewslave/configure
@@ -65,7 +65,16 @@ if __name__ == '__main__':
         sys.exit("Unknown operating system")
 
     USER_LIB_PATH = os.path.abspath('../libraries')
-    ARDUINO_LIBS = 'LCD5110_Basic dallastemperaturecontrol OneWire'
+    ARDUINO_LIBS = 'dallastemperaturecontrol OneWire'
+    config = ""
+
+    if args.with_ntc:
+        config += "#define WITH_NTC     1\n"
+        ARDUINO_LIBS += ' ntc'
+
+    if args.with_lcd5110:
+        config += "#define WITH_LCD5110 1\n"
+        ARDUINO_LIBS += ' LCD5110_Basic'
 
     with open('Makefile', 'w') as f:
         template = string.Template(open('Makefile.in').read())
@@ -79,12 +88,4 @@ if __name__ == '__main__':
         f.write(template.safe_substitute(d))
 
     with open('config.h', 'w') as f:
-        config = ""
-
-        if args.with_lcd5110:
-            config += "#define WITH_LCD5110 1"
-
-        if args.with_ntc:
-            config += "#define WITH_NTC     1"
-
         f.write(config)

--- a/libraries/ntc/ntc.cpp
+++ b/libraries/ntc/ntc.cpp
@@ -1,3 +1,9 @@
+#if ARDUINO >= 100
+#include "Arduino.h"
+#else
+#include "WProgram.h"
+#endif
+
 #include "ntc.h"
 
 

--- a/libraries/ntc/ntc.h
+++ b/libraries/ntc/ntc.h
@@ -1,6 +1,8 @@
 #ifndef NTC_H
 #define NTC_H
 
+#include <inttypes.h>
+
 class NTC {
     public:
         NTC(uint8_t pin);


### PR DESCRIPTION
The class needs to be put into its own directory and suffixed with .cpp. The
configure script was also adapted to include "ntc" when asked for.
