### PR TITLE
Fixed ui not updating when app.update() is fast

### DIFF
--- a/app.cpp
+++ b/app.cpp
@@ -215,7 +215,7 @@ public:
         }
 
         m_ui.set_state(m_ui_state);
-        m_ui.update(elapsed);
+        m_ui.update();
     }
 
 private:

--- a/ui.cpp
+++ b/ui.cpp
@@ -29,13 +29,16 @@ void Ui::set_state(uint8_t state)
     m_state = state;
 }
 
-void Ui::update(unsigned long elapsed)
+void Ui::update()
 {
+    const auto now{millis()};
+
     // Bail out early if there is nothing to redraw.
-    if (elapsed < 15 || (!m_refresh && (m_welcome == nullptr))) {
+    if ((now - m_last_update) < 15 || (!m_refresh && (m_welcome == nullptr))) {
         return;
     }
 
+    m_last_update = now;
     m_display.clear();
 
     if ((m_state & State::UpArrow) != 0) {

--- a/ui.h
+++ b/ui.h
@@ -48,10 +48,8 @@ public:
 
     /**
      * Update internal state and refresh display if necessary.
-     *
-     * @param elapsed Milliseconds elapsed since last update.
      */
-    void update(unsigned long elapsed);
+    void update();
 
 private:
     Display& m_display;
@@ -60,6 +58,7 @@ private:
     uint8_t m_small_number{20};
     uint8_t m_state{0};
     bool m_refresh{true};
+    unsigned long m_last_update{0};
     const char* m_welcome{nullptr};
     const char* m_welcome_last{nullptr};
     uint8_t m_current_scroll_start{127};


### PR DESCRIPTION
Found a glitch in UI updating procedure:
As the `elapsed` argument in the UI referred to the duration of an `app.update()`, the UI was never updated when `app`'s `elapsed` was very small. Hence, the UI needs an update timer independent of `app.update()`. Not sure whether this is ever relevant in real-world application, but during testing it leads to unexpected behavior.