### PR TITLE
Display segmentation reducing buffer size

### DIFF
--- a/app.cpp
+++ b/app.cpp
@@ -215,7 +215,7 @@ public:
         }
 
         m_ui.set_state(m_ui_state);
-        m_ui.update(elapsed);
+        m_ui.update();
     }
 
 private:

--- a/display.h
+++ b/display.h
@@ -32,6 +32,11 @@ public:
     virtual void flush() = 0;
 
     /**
+     * Return true if segmented display buffer is utilized and current segment is not the last segment.
+     */
+    virtual bool next_segment() = 0;
+
+    /**
      * Draw a pixel at coordinate (@p x, @p y) if it falls within width and
      * height.
      *
@@ -65,6 +70,8 @@ public:
     void clear() final {}
 
     void flush() final {}
+
+    bool next_segment() final { return false; }
 
     void draw_pixel(uint8_t, uint8_t) final {}
 

--- a/libs/sh1106/sh1106.cpp
+++ b/libs/sh1106/sh1106.cpp
@@ -63,6 +63,11 @@ void Sh1106::clear()
     }
 }
 
+bool Sh1106::next_segment()
+{
+    return false;
+}
+
 void Sh1106::flush()
 {
     uint8_t* buffer = m_buffer;

--- a/libs/sh1106/sh1106.h
+++ b/libs/sh1106/sh1106.h
@@ -10,6 +10,7 @@ public:
     void begin() final;
     void clear() final;
     void flush() final;
+    bool next_segment() final;
     void draw_pixel(uint8_t x, uint8_t y) final;
     void draw_bitmap(uint8_t x, uint8_t y, Bitmap&& bitmap) final;
 

--- a/libs/sh1107/sh1107.cpp
+++ b/libs/sh1107/sh1107.cpp
@@ -79,7 +79,7 @@ void Sh1107::begin()
 
 void Sh1107::clear()
 {
-    for (size_t i = 0; i < width * height / 8; i++) {
+    for (size_t i = 0; i < width / m_n_segments * height / 8; i++) {
         m_buffer[i] = 0;
     }
 }
@@ -106,13 +106,24 @@ void Sh1107::clear()
 // }
 // }
 
+bool Sh1107::next_segment()
+{
+    if (m_current_segment == m_n_segments) {
+        m_current_segment = 0;
+        return false;
+    }
+    else {
+        return true;
+    }
+}
+
 void Sh1107::flush()
 {
     uint8_t* buffer = m_buffer;
 
-    for (uint8_t page = 0; page < 16; page++) {
+    for (uint8_t page = 0; page < 8; page++) { // total of 16 pages but divided into two segments
         // set page address
-        command(0xB0 + page);
+        command(0xB0 + page + m_current_segment * 8); // segment length is 64 pixel / 8 pixel/page = 8 pages/segment
         // set low column address (address % 16)
         command(0x00);
         // set high column address (0x10 + floor(address / 16))
@@ -126,18 +137,24 @@ void Sh1107::flush()
 
         buffer += height;
     }
+    m_current_segment++;
 }
 
 void Sh1107::draw_pixel(uint8_t x, uint8_t y)
 {
-    if (x > width || y > height)
+    if (x < 64 * m_current_segment || x >= 64 * (m_current_segment + 1) || y > height)
         return;
 
-    m_buffer[(x / 8) * height + y] |= 1 << (x % 8);
+    m_buffer[((x - 64 * m_current_segment) / 8) * height + y] |= 1 << (x % 8);
 }
 
 void Sh1107::draw_bitmap(uint8_t x, uint8_t y, Bitmap&& bitmap)
 {
+    // reduce load by checking if bitmap is entirely outside current segment
+    if (x >= (m_current_segment + 1) * 64 || x + bitmap.width < m_current_segment * 64) {
+        return;
+    }
+
     uint8_t byte_width = (bitmap.width + 7) / 8;
 
     for (uint8_t j = 0; j < bitmap.height; j++) {

--- a/libs/sh1107/sh1107.h
+++ b/libs/sh1107/sh1107.h
@@ -17,6 +17,7 @@ public:
 private:
     void command(uint8_t cmd);
     void clear_ram();
+    void draw_pixel_unchecked(uint8_t x, uint8_t y);
 
     const byte m_rst;
     const byte m_dc;

--- a/libs/sh1107/sh1107.h
+++ b/libs/sh1107/sh1107.h
@@ -10,6 +10,7 @@ public:
     void begin() final;
     void clear() final;
     void flush() final;
+    bool next_segment() final;
     void draw_pixel(uint8_t x, uint8_t y) final;
     void draw_bitmap(uint8_t x, uint8_t y, Bitmap&& bitmap) final;
 
@@ -21,5 +22,7 @@ private:
     const byte m_dc;
     const byte m_din;
     const byte m_clk;
-    uint8_t m_buffer[width * height / 8];
+    static constexpr uint8_t m_n_segments{2};
+    uint8_t m_current_segment{0};
+    uint8_t m_buffer[width / m_n_segments * height / 8];
 };

--- a/libs/ssd1327/ssd1327.cpp
+++ b/libs/ssd1327/ssd1327.cpp
@@ -111,6 +111,11 @@ void Ssd1327::clear()
     }
 }
 
+bool Ssd1327::next_segment()
+{
+    return false;
+}
+
 void Ssd1327::flush()
 {
     uint8_t* buffer = m_buffer;

--- a/libs/ssd1327/ssd1327.h
+++ b/libs/ssd1327/ssd1327.h
@@ -10,6 +10,7 @@ public:
     void begin() final;
     void clear() final;
     void flush() final;
+    bool next_segment() final;
     void draw_pixel(uint8_t x, uint8_t y) final;
     void draw_bitmap(uint8_t x, uint8_t y, Bitmap&& bitmap) final;
 

--- a/ui.cpp
+++ b/ui.cpp
@@ -29,13 +29,16 @@ void Ui::set_state(uint8_t state)
     m_state = state;
 }
 
-void Ui::update(unsigned long elapsed)
+void Ui::update()
 {
+    const auto now{millis()};
+
     // Bail out early if there is nothing to redraw.
-    if (elapsed < 15 || (!m_refresh && (m_welcome == nullptr))) {
+    if ((now - m_last_update) < 15 || (!m_refresh && (m_welcome == nullptr))) {
         return;
     }
 
+    m_last_update = now;
     m_display.clear();
 
     if ((m_state & State::UpArrow) != 0) {

--- a/ui.cpp
+++ b/ui.cpp
@@ -39,27 +39,58 @@ void Ui::update()
     }
 
     m_last_update = now;
-    m_display.clear();
 
-    if ((m_state & State::UpArrow) != 0) {
-        m_display.draw_bitmap(70, 0, Bitmap{11, 6, ICON_ARROW_UP_11_6});
-    }
+    do {
+        m_display.clear();
 
-    if ((m_state & State::DownArrow) != 0) {
-        m_display.draw_bitmap(70, m_display.height - 1 - 6, Bitmap{11, 6, ICON_ARROW_DOWN_11_6});
-    }
+        if ((m_state & State::UpArrow) != 0) {
+            m_display.draw_bitmap(70, 0, Bitmap{11, 6, ICON_ARROW_UP_11_6});
+        }
 
-    if ((m_state & State::Warning) != 0) {
-        m_display.draw_bitmap(m_display.width - 1 - 22, m_display.height - 1 - 22, Bitmap{22, 22, ICON_WARNING_22_22});
-    }
+        if ((m_state & State::DownArrow) != 0) {
+            m_display.draw_bitmap(70, m_display.height - 1 - 6, Bitmap{11, 6, ICON_ARROW_DOWN_11_6});
+        }
+
+        if ((m_state & State::Warning) != 0) {
+            m_display.draw_bitmap(m_display.width - 1 - 22, m_display.height - 1 - 22, Bitmap{22, 22, ICON_WARNING_22_22});
+        }
+
+        if (*m_welcome_last != '\0') {
+            // This is pretty choppy because of the uneven loop timing. There are
+            // two options: we schedule the UI updates at precise points in time or
+            // use ye olde trick of time-dependent updates. But not super important
+            // for now, I'd say.
+            m_pico.draw(m_welcome_last, m_current_scroll_start, 63 - 6);
+        }
+
+        if (m_big_number != 0) {
+            m_display.draw_bitmap(0, 0, Bitmap{36, 64, DIGITS_36_64[m_big_number / 10]});
+            m_display.draw_bitmap(36, 0, Bitmap{36, 64, DIGITS_36_64[m_big_number % 10]});
+        }
+        else {
+            m_display.draw_bitmap(0, 30, Bitmap{36, 4, DASH_36_4});
+            m_display.draw_bitmap(36, 30, Bitmap{36, 4, DASH_36_4});
+        }
+
+        if ((m_state & State::SmallUpArrow) != 0) {
+            m_display.draw_bitmap(m_display.width - 1 - 2 * 18 - 8, 0, Bitmap{6, 3, ICON_SMALL_ARROW_UP_6_3});
+        }
+
+        if ((m_state & State::SmallDownArrow) != 0) {
+            m_display.draw_bitmap(m_display.width - 1 - 2 * 18 - 8, 29, Bitmap{6, 3, ICON_SMALL_ARROW_DOWN_6_3});
+        }
+
+        if ((m_state & State::SmallEq) != 0) {
+            m_display.draw_bitmap(m_display.width - 1 - 2 * 18 - 8, 14, Bitmap{6, 5, ICON_SMALL_ARROW_EQ_6_5});
+        }
+
+        m_display.draw_bitmap(m_display.width - 1 - 2 * 18, 0, Bitmap{18, 32, DIGITS_18_32[m_small_number / 10]});
+        m_display.draw_bitmap(m_display.width - 1 - 1 * 18, 0, Bitmap{18, 32, DIGITS_18_32[m_small_number % 10]});
+
+        m_display.flush();
+    } while (m_display.next_segment());
 
     if (*m_welcome_last != '\0') {
-        // This is pretty choppy because of the uneven loop timing. There are
-        // two options: we schedule the UI updates at precise points in time or
-        // use ye olde trick of time-dependent updates. But not super important
-        // for now, I'd say.
-        m_pico.draw(m_welcome_last, m_current_scroll_start, 63 - 6);
-
         if (m_current_scroll_start > 69) {
             m_current_scroll_start--;
         }
@@ -69,30 +100,5 @@ void Ui::update()
         }
     }
 
-    if (m_big_number != 0) {
-        m_display.draw_bitmap(0, 0, Bitmap{36, 64, DIGITS_36_64[m_big_number / 10]});
-        m_display.draw_bitmap(36, 0, Bitmap{36, 64, DIGITS_36_64[m_big_number % 10]});
-    }
-    else {
-        m_display.draw_bitmap(0, 30, Bitmap{36, 4, DASH_36_4});
-        m_display.draw_bitmap(36, 30, Bitmap{36, 4, DASH_36_4});
-    }
-
-    if ((m_state & State::SmallUpArrow) != 0) {
-        m_display.draw_bitmap(m_display.width - 1 - 2 * 18 - 8, 0, Bitmap{6, 3, ICON_SMALL_ARROW_UP_6_3});
-    }
-
-    if ((m_state & State::SmallDownArrow) != 0) {
-        m_display.draw_bitmap(m_display.width - 1 - 2 * 18 - 8, 29, Bitmap{6, 3, ICON_SMALL_ARROW_DOWN_6_3});
-    }
-
-    if ((m_state & State::SmallEq) != 0) {
-        m_display.draw_bitmap(m_display.width - 1 - 2 * 18 - 8, 14, Bitmap{6, 5, ICON_SMALL_ARROW_EQ_6_5});
-    }
-
-    m_display.draw_bitmap(m_display.width - 1 - 2 * 18, 0, Bitmap{18, 32, DIGITS_18_32[m_small_number / 10]});
-    m_display.draw_bitmap(m_display.width - 1 - 1 * 18, 0, Bitmap{18, 32, DIGITS_18_32[m_small_number % 10]});
-
-    m_display.flush();
     m_refresh = false;
 }

--- a/ui.h
+++ b/ui.h
@@ -48,10 +48,8 @@ public:
 
     /**
      * Update internal state and refresh display if necessary.
-     *
-     * @param elapsed Milliseconds elapsed since last update.
      */
-    void update(unsigned long elapsed);
+    void update();
 
 private:
     Display& m_display;
@@ -60,6 +58,7 @@ private:
     uint8_t m_small_number{20};
     uint8_t m_state{0};
     bool m_refresh{true};
+    unsigned long m_last_update{0};
     const char* m_welcome{nullptr};
     const char* m_welcome_last{nullptr};
     uint8_t m_current_scroll_start{127};


### PR DESCRIPTION
@matze as discussed the issue with the occasional display droput #27 may be am RAM issue. I've tripple checked the wiring and did some testing with low-RAM code, which all works fine without display glitches.

Hence, I've split the display buffer into two segments for my display (`sh1107`). This resolves the issue for me.

In order for this to work, I had to rewrite the ui putting every command writing to the buffer within
```
do {
[...]
} while (m_display.next_segment());
```
This repeats for each segment. Therefore, I had to moved the welcome message scrolling outside this loop in order to avoid increased scrolling speed when utilizing a segmented buffer.

For now, I've added a dummy function `next_segment()` to all other display libraries (`sh1106` and `ssd1327`) in order to keep them working without segmenting their buffer. They compile fine for me but I did not test this with hardware.

@matze can you test this with your display to check if it still works?


